### PR TITLE
README formatting fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,13 @@
 [![Build Status](https://travis-ci.org/Alorel/dropbox-v2-php.svg?branch=master)](https://travis-ci.org/Alorel/dropbox-v2-php)
 [![codecov](https://codecov.io/gh/Alorel/dropbox-v2-php/branch/master/graph/badge.svg)](https://codecov.io/gh/Alorel/dropbox-v2-php)
 [![Dependency Status](https://www.versioneye.com/user/projects/5756bd6b7757a0004a1de150/badge.svg)](https://www.versioneye.com/user/projects/5756bd6b7757a0004a1de150)
-[![Reference Status](https://www.versioneye.com/php/alorel:dropbox-v2-php/reference_badge.svg)](https://www.versioneye.com/php/alorel:dropbox-v2-php/references)
 
 [![Latest Stable Version](https://poser.pugx.org/alorel/dropbox-v2-php/v/stable)](https://packagist.org/packages/alorel/dropbox-v2-php)
 [![Total Downloads](https://poser.pugx.org/alorel/dropbox-v2-php/downloads)](https://packagist.org/packages/alorel/dropbox-v2-php)
 [![License](https://poser.pugx.org/alorel/dropbox-v2-php/license)](https://packagist.org/packages/alorel/dropbox-v2-php)
 
-![Tested](https://php-eye.com/badge/alorel/dropbox-v2-php/tested.svg)
-![Not tested](https://php-eye.com/badge/alorel/dropbox-v2-php/not-tested.svg)
+
+Tested with PHP 5.6-7.1 and HHVM 3.18. See the [CI builds](https://travis-ci.org/Alorel/dropbox-v2-php/builds) page for the most accurate, up-to-date version list.
 
 ----------
 
@@ -21,22 +20,25 @@
 
 A PHP SDK for Dropbox's v2 API. If you haven't tried Dropbox out yet, [do](https://db.tt/u56WHf8q "referral link") - it's great!
 
-#Table of Contents
+# Table of Contents
 
  1. [Installation](#installation)
  1. [Usage](#usage)
  1. [Supported API operations](#supported-api-operations)
  1. [API Documentation](#api-documentation)
 
-#Installation
+# Installation
+
 Installation is only available via [Composer](https://getcomposer.org/).
 
-##Quick version:
+## Quick version:
+
 ```sh
 composer require alorel/dropbox-v2-php
 ```
 
-##More informed version:
+## More informed version:
+
 The package is still in its `0.x` development stage, therefore adding it as a `^` dependency, e.g. `"alorel/dropbox-v2-php":"^0.1"` will severely limit the amount of updates you receive, as, per [semver](http://semver.org/#spec-item-4) specification, `0.2` is allowed to be backwards-incompatible with `0.1`. While I definitely cannot guarantee **full** backwards compatibility if you fiddle with protected methods and derive your own subclasses, I do guarantee that the public API will remain backwards-compatible, therefore, if you only use the `raw` methods in your application e.g.
 
 ```php
@@ -56,7 +58,8 @@ You can safely add the following as a dependency in your composer.json:
 
 Additionally, `composer outdated` is a useful command to know during the `0.x` development stage!
 
-#Usage
+# Usage
+
 Every Dropbox API operation is located in the [\Alorel\Dropbox\Operation](https://cdn.rawgit.com/Alorel/dropbox-v2-php/0.3.3/docs/master/Alorel/Dropbox/Operation.html) namespace and is a class named after the API endpoint. There are a few exceptions to this, however, e.g. the class for `https://content.dropboxapi.com/2/files/upload_session/start` is `\Alorel\Dropbox\Operation\Files\UploadSession\Start`. 
 
 All operation classes inherit the AbstractOperation constructor:
@@ -77,7 +80,8 @@ Currently the only supported way of making requests is with the respective opera
 
 In future releases I will be adding 'management' classes that will automatically format the response.
 
-#Supported API Operations
+# Supported API Operations
+
 Unless specified otherwise, any operation that is not currently supported will be added in a future release.
 
 ## Files
@@ -96,7 +100,8 @@ All except:
 
 All
 
-#API Documentation
+# API Documentation
+
 [0.4](https://cdn.rawgit.com/Alorel/dropbox-v2-php/0.4/docs/master/index.html) |
 [0.3.3](https://cdn.rawgit.com/Alorel/dropbox-v2-php/0.3.3/docs/master/index.html) |
 [0.2](https://cdn.rawgit.com/Alorel/dropbox-v2-php/0.2/docs/master/index.html) |
@@ -106,6 +111,7 @@ All
 ----------
 
 # Links
+
  - [Changelog](https://github.com/Alorel/dropbox-v2-php/releases)
  - [Dropbox HTTP API docs](https://www.dropbox.com/developers/documentation/http/documentation) (this library is merely a HTTP request wrapper)
  - [Dropbox API explorer](https://dropbox.github.io/dropbox-api-v2-explorer)


### PR DESCRIPTION
Fixed some heading formatting in the README

GitHub was previously lax with its Markdown parsing which recently changed.

[ci skip]